### PR TITLE
feat: run integration tests against Docker containers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,17 +6,6 @@ on:
       ref:
         required: true
         type: string
-    secrets:
-      BASE_URL:
-        required: false
-      AUTH_TOKEN:
-        required: false
-      JWT_KEY:
-        required: false
-      CLIENT_ID:
-        required: false
-      CLIENT_SECRET:
-        required: false
 
 defaults:
   run:
@@ -48,12 +37,6 @@ jobs:
 
       - name: Run Tests
         run: composer test
-        env:
-          BASE_URL: ${{ secrets.BASE_URL }}
-          AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
-          JWT_KEY: ${{ secrets.JWT_KEY }}
-          CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
       - name: Upload Results
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/etc/docker-compose.yaml
+++ b/etc/docker-compose.yaml
@@ -1,0 +1,89 @@
+services:
+  db:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: postgres
+    networks:
+      - storage
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready", "-d", "db_prod" ]
+      interval: 10s
+      timeout: 60s
+      retries: 5
+      start_period: 10s
+    volumes:
+      - data:/var/lib/postgresql/data:rw
+
+  zitadel-init:
+    restart: 'no'
+    networks:
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest'
+    command: 'init --config /example-zitadel-config.yaml --config /example-zitadel-secrets.yaml'
+    depends_on:
+      db:
+        condition: 'service_healthy'
+    volumes:
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './zitadel_output:/var/zitadel_output:rw'
+
+  zitadel-setup:
+    restart: 'no'
+    networks:
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest-debug'
+    user: root
+    entrypoint: '/bin/bash'
+    command: [ "-c", "/app/zitadel setup --config /example-zitadel-config.yaml --config /example-zitadel-secrets.yaml --steps /example-zitadel-init-steps.yaml --masterkey \"my_test_masterkey_0123456789ABEF\" && echo \"--- ZITADEL SETUP COMPLETE ---\" && echo \"Personal Access Token (PAT) will be in ./zitadel_output/pat.txt on your host.\" && echo \"Service Account Key will be in ./zitadel_output/sa-key.json on your host.\" && echo \"OAuth Client ID and Secret will be in 'zitadel' service logs (grep for 'Application created').\"" ]
+    environment:
+      - PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app
+    depends_on:
+      zitadel-init:
+        condition: 'service_completed_successfully'
+        restart: false
+    volumes:
+      - './zitadel_output:/var/zitadel_output:rw'
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './example-zitadel-init-steps.yaml:/example-zitadel-init-steps.yaml:ro'
+
+  zitadel:
+    restart: 'unless-stopped'
+    networks:
+      - backend
+      - storage
+    image: 'ghcr.io/zitadel/zitadel:latest'
+    command: >
+      start --config /example-zitadel-config.yaml
+      --config /example-zitadel-secrets.yaml
+      --masterkey my_test_masterkey_0123456789ABEF
+    depends_on:
+      zitadel-setup:
+        condition: 'service_completed_successfully'
+        restart: true
+    volumes:
+      - './example-zitadel-config.yaml:/example-zitadel-config.yaml:ro'
+      - './example-zitadel-secrets.yaml:/example-zitadel-secrets.yaml:ro'
+      - './zitadel_output:/var/zitadel_output:rw'
+    ports:
+      - "8099:8080"
+    healthcheck:
+      test: [
+        "CMD", "/app/zitadel", "ready",
+        "--config", "/example-zitadel-config.yaml",
+        "--config", "/example-zitadel-secrets.yaml"
+      ]
+      interval: 10s
+      timeout: 60s
+      retries: 5
+      start_period: 10s
+
+networks:
+  storage: { }
+  backend: { }
+
+volumes:
+  data: { }

--- a/etc/example-zitadel-config.yaml
+++ b/etc/example-zitadel-config.yaml
@@ -1,0 +1,17 @@
+ExternalSecure: false
+ExternalDomain: localhost
+ExternalPort: 8080
+TLS.Enabled: false
+Database:
+  postgres:
+    Host: 'db'
+    Port: 5432
+    Database: zitadel
+    User.SSL.Mode: 'disable'
+    Admin.SSL.Mode: 'disable'
+OIDC:
+  DefaultLoginURLV2: "/ui/v2/login/login?authRequest="
+  DefaultLogoutURLV2: "/ui/v2/login/logout?post_logout_redirect="
+SAML.DefaultLoginURLV2: "/ui/v2/login/login?authRequest="
+LogStore.Access.Stdout.Enabled: true
+DefaultInstance.LoginPolicy.MfaInitSkipLifetime: "0s"

--- a/etc/example-zitadel-init-steps.yaml
+++ b/etc/example-zitadel-init-steps.yaml
@@ -1,0 +1,35 @@
+FirstInstance:
+  MachineKeyPath: '/var/zitadel_output/sa-key.json'
+  PatPath: '/var/zitadel_output/pat.txt'
+  Org:
+    Human:
+      PasswordChangeRequired: false
+      Username: zitadel-admin@zitadel.localhost
+      Password: Password1!
+    Machine:
+      Machine:
+        Username: api-user
+        Name: Combined API User
+      MachineKey:
+        ExpirationDate: '2030-01-01T00:00:00Z'
+        Type: 1
+      Pat:
+        ExpirationDate: '2030-01-01T00:00:00Z'
+  Applications:
+    - OIDC:
+        RedirectUris:
+          - http://localhost:8080/callback
+          - http://127.0.0.1:8080/callback
+        ResponseTypes:
+          - CODE
+          - ID_TOKEN
+          - TOKEN
+        GrantTypes:
+          - AUTHORIZATION_CODE
+          - IMPLICIT
+          - REFRESH_TOKEN
+          - CLIENT_CREDENTIALS
+        AuthMethodType: POST
+      Name: 'MyOAuthAPIClient'
+      Type: 'WEB'
+DefaultInstance.LoginPolicy.MfaInitSkipLifetime: "0s"

--- a/etc/example-zitadel-secrets.yaml
+++ b/etc/example-zitadel-secrets.yaml
@@ -1,0 +1,8 @@
+Database:
+  postgres:
+    User:
+      Username: 'zitadel_user'
+      Password: 'zitadel'
+    Admin:
+      Username: 'root'
+      Password: 'postgres'

--- a/spec/AbstractIntegrationTest.php
+++ b/spec/AbstractIntegrationTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Zitadel\Client\Spec;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+/**
+ * Abstract base class for integration tests that interact with a Docker
+ * Compose stack.
+ *
+ * This class handles the lifecycle of a Docker Compose environment,
+ * bringing it up before tests run and tearing it down afterwards. It also
+ * provides mechanisms to load specific data (like authentication tokens
+ * and JWT keys) from files and make them accessible via protected getters
+ * for use in concrete test implementations.
+ */
+abstract class AbstractIntegrationTest extends TestCase
+{
+    /**
+     * @var string|null The authentication token loaded from file.
+     */
+    protected static ?string $authToken = null;
+    /**
+     * @var string|null The absolute path to the JWT key file.
+     */
+    protected static ?string $jwtKey = null;
+    /**
+     * @var string|null The base URL for the services.
+     */
+    protected static ?string $baseUrl = null;
+    /**
+     * @var string The absolute path to the docker-compose.yaml file.
+     */
+    private static string $composeFilePath = __DIR__ . '/../etc/docker-compose.yaml';
+    /**
+     * @var string|null The directory containing the docker-compose.yaml file.
+     */
+    private static ?string $composeFileDir = null;
+
+    /**
+     * Sets up the test environment before the first test in the class runs.
+     * This includes bringing up the Docker Compose stack and exposing
+     * necessary data.
+     *
+     * @throws RuntimeException If the Docker Compose stack fails to start.
+     * @throws Exception If a required file for data is not found or
+     * cannot be read.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        self::$composeFileDir = dirname(self::$composeFilePath);
+
+        echo "Bringing up Docker Compose stack...\n";
+        $command = "docker compose -f " . escapeshellarg(self::$composeFilePath)
+            . " up --detach --no-color --quiet-pull --yes";
+        exec($command, $output, $returnCode);
+
+        foreach ($output as $line) {
+            echo "STDOUT: " . $line . "\n";
+        }
+
+        if ($returnCode !== 0) {
+            $errorMessage = "Failed to bring up Docker Compose stack. Exit code: "
+                . $returnCode . "\n" . implode("\n", $output);
+            error_log($errorMessage);
+            throw new RuntimeException($errorMessage);
+        }
+        echo "Docker Compose stack is up.\n";
+
+        // Load AUTH_TOKEN content from file
+        self::loadFileContentIntoProperty('zitadel_output/pat.txt', 'authToken');
+
+        // Set JWT_KEY to the absolute path of the file
+        $jwtKeyFilePath = self::$composeFileDir . DIRECTORY_SEPARATOR
+            . 'zitadel_output/sa-key.json';
+        if (!file_exists($jwtKeyFilePath)) {
+            throw new Exception("JWT Key file not found at path: {$jwtKeyFilePath}");
+        }
+        self::$jwtKey = $jwtKeyFilePath;
+        echo "Loaded JWT_KEY path: " . self::$jwtKey . "\n";
+
+
+        self::$baseUrl = 'http://localhost:8099';
+        echo "Exposed BASE_URL as: " . self::$baseUrl . "\n";
+
+        sleep(20);
+    }
+
+    /**
+     * Reads the content of a file relative to the compose file directory and
+     * assigns it to a specified static property of this class.
+     * This method is intended for loading *content*, not paths.
+     *
+     * @param string $relativePath The path to the file, relative to the
+     * compose file's directory.
+     * @param string $propertyName The name of the static property (e.g.,
+     * 'authToken') to assign the content to.
+     * @throws Exception If the file is not found or cannot be read.
+     */
+    private static function loadFileContentIntoProperty(
+        string $relativePath,
+        string $propertyName
+    ): void {
+        $filePath = self::$composeFileDir . DIRECTORY_SEPARATOR . $relativePath;
+
+        if (file_exists($filePath)) {
+            $content = file_get_contents($filePath);
+            if ($content !== false) {
+                self::$$propertyName = trim($content);
+                echo "Loaded {$filePath} content into property: {$propertyName}\n";
+            } else {
+                throw new Exception("Could not read content of file: $filePath for "
+                    . "property '{$propertyName}'");
+            }
+        } else {
+            throw new Exception("File not found for property '$propertyName': "
+                . "{$filePath}");
+        }
+    }
+
+    /**
+     * Tears down the test environment after all tests in the class have run.
+     * This includes stopping and removing the Docker Compose stack.
+     *
+     * @throws Exception If the Docker Compose file path is invalid or the
+     * stack fails to tear down.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        echo "Tearing down Docker Compose stack...\n";
+        if (file_exists(self::$composeFilePath)) {
+            $command = "docker compose -f " . escapeshellarg(self::$composeFilePath)
+                . " down -v";
+            exec($command, $output, $returnCode);
+
+            foreach ($output as $line) {
+                echo "STDOUT: " . $line . "\n";
+            }
+
+            if ($returnCode !== 0) {
+                error_log("Warning: Failed to tear down Docker Compose stack. Exit "
+                    . "code: " . $returnCode . "\n" . implode("\n", $output));
+                throw new Exception(
+                    "Failed to tear down Docker Compose stack. Exit code: "
+                    . $returnCode . "\n" . implode("\n", $output)
+                );
+            }
+        } else {
+            throw new Exception("Docker Compose file path not initialized or file "
+                . "does not exist, skipping tear down.");
+        }
+        echo "Docker Compose stack torn down.\n";
+    }
+
+    /**
+     * Retrieves the authentication token.
+     *
+     * @return string|null The authentication token, or null if not set.
+     */
+    protected static function getAuthToken(): ?string
+    {
+        return self::$authToken;
+    }
+
+    /**
+     * Retrieves the absolute path to the JWT key file.
+     *
+     * @return string|null The absolute path to the JWT key file, or null
+     * if not set.
+     */
+    protected static function getJwtKey(): ?string
+    {
+        return self::$jwtKey;
+    }
+
+    /**
+     * Retrieves the base URL.
+     *
+     * @return string|null The base URL, or null if not set.
+     */
+    protected static function getBaseUrl(): ?string
+    {
+        return self::$baseUrl;
+    }
+}

--- a/spec/Auth/UseAccessTokenSpec.php
+++ b/spec/Auth/UseAccessTokenSpec.php
@@ -3,8 +3,8 @@
 namespace Zitadel\Client\Spec\Auth;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
 use Zitadel\Client\ApiException;
+use Zitadel\Client\Spec\AbstractIntegrationTest;
 use Zitadel\Client\Zitadel;
 use Zitadel\Client\ZitadelException;
 
@@ -17,7 +17,7 @@ use Zitadel\Client\ZitadelException;
  *  1. Retrieve general settings successfully with a valid token
  *  2. Expect an ApiException when using an invalid token
  */
-class UseAccessTokenSpec extends TestCase
+class UseAccessTokenSpec extends AbstractIntegrationTest
 {
     /**
      * Validate retrieval of general settings with a valid PAT.
@@ -27,20 +27,8 @@ class UseAccessTokenSpec extends TestCase
      */
     public function testRetrievesGeneralSettingsWithValidAuth(): void
     {
-        $client = Zitadel::withAccessToken(
-            self::env('BASE_URL'),
-            self::env('AUTH_TOKEN')
-        );
-
+        $client = Zitadel::withAccessToken(self::getBaseUrl(), self::getAuthToken());
         $client->settings->settingsServiceGetGeneralSettings();
-    }
-
-    /**
-     * Retrieve a configuration variable from the environment, falling back to $_ENV.
-     */
-    private static function env(string $key): string
-    {
-        return getenv($key) ?: ($_ENV[$key] ?? '');
     }
 
     /**
@@ -49,10 +37,7 @@ class UseAccessTokenSpec extends TestCase
      */
     public function testRaisesApiExceptionWithInvalidAuth(): void
     {
-        $invalid = Zitadel::withAccessToken(
-            self::env('BASE_URL'),
-            'invalid'
-        );
+        $invalid = Zitadel::withAccessToken(self::getBaseUrl(), 'invalid');
 
         $this->expectException(ZitadelException::class);
         $invalid->settings->settingsServiceGetGeneralSettings();

--- a/spec/Auth/UseClientCredentialsSpec.php
+++ b/spec/Auth/UseClientCredentialsSpec.php
@@ -3,8 +3,8 @@
 namespace Zitadel\Client\Spec\Auth;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
 use Zitadel\Client\ApiException;
+use Zitadel\Client\Spec\AbstractIntegrationTest;
 use Zitadel\Client\Zitadel;
 use Zitadel\Client\ZitadelException;
 
@@ -17,8 +17,69 @@ use Zitadel\Client\ZitadelException;
  *  1. Retrieve general settings successfully with valid credentials
  *  2. Expect an ApiException when using invalid credentials
  */
-class UseClientCredentialsSpec extends TestCase
+class UseClientCredentialsSpec extends AbstractIntegrationTest
 {
+    /**
+     *
+     * @return array{clientId: string, clientSecret: string}
+     * @throws Exception
+     */
+    public function generateUserSecret(string $token, string $loginName = 'api-user'): array
+    {
+        $userIdResponse = @file_get_contents(
+            'http://localhost:8099/management/v1/global/users/_by_login_name?loginName=' . urlencode($loginName),
+            false,
+            stream_context_create(['http' => [
+                'header' => "Authorization: Bearer $token\r\nAccept: application/json",
+                'ignore_errors' => true
+            ]])
+        );
+
+        if ($userIdResponse !== false) {
+            $userId = json_decode($userIdResponse, true)['user']['id'] ?? null;
+
+            if ($userId) {
+                $secretResponse = @file_get_contents(
+                    "http://localhost:8099/management/v1/users/$userId/secret",
+                    false,
+                    stream_context_create([
+                        'http' => [
+                            'method'  => 'PUT',
+                            'header'  => "Authorization: Bearer $token\r\n" .
+                                "Content-Type: application/json\r\n" .
+                                "Accept: application/json",
+                            'content' => '{}',
+                            'ignore_errors' => true
+                        ]
+                    ])
+                );
+
+                if ($secretResponse !== false) {
+                    $secretData = json_decode($secretResponse, true);
+                    $clientId = $secretData['clientId'] ?? null;
+                    $clientSecret = $secretData['clientSecret'] ?? null;
+
+                    if ($clientId && $clientSecret) {
+                        return [
+                            'clientId' => $clientId,
+                            'clientSecret' => $clientSecret
+                        ];
+                    } else {
+                        print_r($secretResponse);
+                        throw new Exception("API response for secret is missing 'clientId' or 'clientSecret'.");
+                    }
+                } else {
+                    throw new Exception("API call to generate secret failed for user ID: '$userId'.");
+                }
+            } else {
+                print_r($userIdResponse);
+                throw new Exception("Could not parse a valid user ID from API response for login name: '$loginName'.");
+            }
+        } else {
+            throw new Exception("API call to retrieve user failed for login name: '$loginName'.");
+        }
+    }
+
     /**
      * Validate retrieval of general settings with valid client credentials.
      *
@@ -28,21 +89,10 @@ class UseClientCredentialsSpec extends TestCase
      */
     public function testRetrievesGeneralSettingsWithValidAuth(): void
     {
-        $client = Zitadel::withClientCredentials(
-            self::env('BASE_URL'),
-            self::env('CLIENT_ID'),
-            self::env('CLIENT_SECRET')
-        );
+        $credentials = $this->generateUserSecret(self::getAuthToken());
+        $client = Zitadel::withClientCredentials(self::getBaseUrl(), $credentials['clientId'], $credentials['clientSecret']);
 
         $client->settings->settingsServiceGetGeneralSettings();
-    }
-
-    /**
-     * Retrieve a configuration variable from the environment, falling back to $_ENV.
-     */
-    private static function env(string $key): string
-    {
-        return getenv($key) ?: ($_ENV[$key] ?? '');
     }
 
     /**
@@ -51,11 +101,7 @@ class UseClientCredentialsSpec extends TestCase
      */
     public function testRaisesApiExceptionWithInvalidAuth(): void
     {
-        $invalid = Zitadel::withClientCredentials(
-            self::env('BASE_URL'),
-            'invalid',
-            'invalid'
-        );
+        $invalid = Zitadel::withClientCredentials(self::getBaseUrl(), 'invalid', 'invalid');
 
         $this->expectException(ZitadelException::class);
         $invalid->settings->settingsServiceGetGeneralSettings();

--- a/spec/Auth/UsePrivateKeySpec.php
+++ b/spec/Auth/UsePrivateKeySpec.php
@@ -3,8 +3,8 @@
 namespace Zitadel\Client\Spec\Auth;
 
 use Exception;
-use PHPUnit\Framework\TestCase;
 use Zitadel\Client\ApiException;
+use Zitadel\Client\Spec\AbstractIntegrationTest;
 use Zitadel\Client\Zitadel;
 use Zitadel\Client\ZitadelException;
 
@@ -17,7 +17,7 @@ use Zitadel\Client\ZitadelException;
  *  1. Retrieve general settings successfully with a valid private key
  *  2. Expect an ApiException when using an invalid private key
  */
-class UsePrivateKeySpec extends TestCase
+class UsePrivateKeySpec extends AbstractIntegrationTest
 {
     /**
      * Validate retrieval of general settings with a valid private key assertion.
@@ -28,28 +28,8 @@ class UsePrivateKeySpec extends TestCase
      */
     public function testRetrievesGeneralSettingsWithValidAuth(): void
     {
-        $client = Zitadel::withPrivateKey(
-            self::env('BASE_URL'),
-            self::createTempJwtFile()
-        );
-
+        $client = Zitadel::withPrivateKey(self::getBaseUrl(), self::getJwtKey());
         $client->settings->settingsServiceGetGeneralSettings();
-    }
-
-    /**
-     * Retrieve a configuration variable from the environment, falling back to $_ENV.
-     */
-    private static function env(string $key): string
-    {
-        return getenv($key) ?: ($_ENV[$key] ?? '');
-    }
-
-    private static function createTempJwtFile(): string
-    {
-        $k = self::env('JWT_KEY');
-        $p = tempnam(sys_get_temp_dir(), 'jwt_') or exit;
-        file_put_contents($p, $k) or exit;
-        return $p;
     }
 
     /**
@@ -58,10 +38,7 @@ class UsePrivateKeySpec extends TestCase
      */
     public function testRaisesApiExceptionWithInvalidAuth(): void
     {
-        $invalid = Zitadel::withPrivateKey(
-            "https://zitadel.cloud",
-            self::createTempJwtFile()
-        );
+        $invalid = Zitadel::withPrivateKey("https://zitadel.cloud", self::getJwtKey());
 
         $this->expectException(ZitadelException::class);
         $invalid->settings->settingsServiceGetGeneralSettings();

--- a/spec/UserServiceSanityCheckSpec.php
+++ b/spec/UserServiceSanityCheckSpec.php
@@ -2,7 +2,6 @@
 
 namespace Zitadel\Client\Spec;
 
-use PHPUnit\Framework\TestCase;
 use Zitadel\Client\ApiException;
 use Zitadel\Client\Model\UserServiceAddHumanUserRequest;
 use Zitadel\Client\Model\UserServiceAddHumanUserResponse;
@@ -22,32 +21,21 @@ use Zitadel\Client\Zitadel;
  *  1. Create a human user
  *  2. Retrieve the user by ID
  *  3. List users and ensure the created user appears
- *  4. Update the user's email and confirm the change
+ *  4. Update the user's email and confirm change
  *  5. Error when retrieving a non-existent user
  *
  * Each test runs in isolation: a new user is created in setUp() and removed in
  * tearDown() to ensure a clean state.
  */
-class UserServiceSanityCheckSpec extends TestCase
+class UserServiceSanityCheckSpec extends AbstractIntegrationTest
 {
-    protected static string $validToken;
-    protected static string $baseUrl;
     protected static Zitadel $client;
     protected UserServiceAddHumanUserResponse $user;
 
     public static function setUpBeforeClass(): void
     {
-        self::$validToken = self::env('AUTH_TOKEN');
-        self::$baseUrl = self::env('BASE_URL');
-        self::$client = Zitadel::withAccessToken(self::$baseUrl, self::$validToken);
-    }
-
-    /**
-     * Retrieve a configuration variable from the environment, falling back to $_ENV.
-     */
-    private static function env(string $key): string
-    {
-        return getenv($key) ?: ($_ENV[$key] ?? '');
+        parent::setUpBeforeClass();
+        self::$client = Zitadel::withAccessToken(self::getBaseUrl(), self::getAuthToken());
     }
 
     /**


### PR DESCRIPTION
## Description

This PR refactors the integration test setup to use TestContainers with Docker Compose instead of relying on a production instance. It ensures that integration tests run in a controlled, versioned environment without requiring sensitive production tokens, and enables public contributors to successfully run the tests in their pull requests.

## Motivation and Context

The current integration tests depend on a production instance, causing issues such as failing public PR tests due to missing credentials and inconsistent environments. This change solves these problems by:
- Ensuring tests can run consistently on a versioned setup.
- Removing the need for sensitive production tokens.
- Enabling public contributions to pass the integration tests.
- Reducing reliance on external services for testing.

## How Has This Been Tested?

- **Local Testing:** I tested the new setup locally by running the integration tests using TestContainers with Docker Compose.
- **CI/CD Testing:** I updated the GitHub Actions CI/CD pipeline to spin up the necessary containers and run tests.
- **Integration with Existing Code:** Verified that the new setup does not break existing functionality and ensures all tests pass with the controlled test environment.

## Documentation:

N/A

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [x] I have correctly labeled this pull request.
- [x] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers.
- [x] I have checked the base branch of this pull request.
- [x] I have checked my code for any possible security vulnerabilities.